### PR TITLE
Hit width in css

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -27,5 +27,8 @@ code {
    --key-width: 9.5vw;
    --space-width: 47vw;
 
-   --num-minis-in-row: 3;
+   --easy-central: 50%;
+   --easy-peripheral: 25%;
+   --hard-central: 33%;
+   --hard-peripheral: 33%;
 }

--- a/src/models/WholeKey.ts
+++ b/src/models/WholeKey.ts
@@ -7,6 +7,7 @@ export interface MiniBoxProps {
    keyboardCounter: number;
    gradientRecord: number[];
    setGradientRecord: React.Dispatch<React.SetStateAction<number[]>>;
+   isEasy: boolean;
 }
 
 export interface WholeKeyProps {
@@ -16,4 +17,5 @@ export interface WholeKeyProps {
    keyboardCounter: number;
    typedSentence: string;
    setTypedSentence: React.Dispatch<React.SetStateAction<string>>;
+   isEasy: boolean;
 }

--- a/src/routes/TypingPage/components/KeyboardAndConsoleSection/index.tsx
+++ b/src/routes/TypingPage/components/KeyboardAndConsoleSection/index.tsx
@@ -11,6 +11,7 @@ export const KeyboardAndConsoleSection: React.FC<{
    const [keyboardCounter, setKeyboardCounter] = useState(0);
    const [bullseyeCounter, setBullseyeCounter] = useState(0);
    const [typedSentence, setTypedSentence] = useState('');
+   const [isEasy, setIsEasy] = useState(true);
 
    return (
       <div className={styles.keyboardAndConsoleSection}>
@@ -20,6 +21,8 @@ export const KeyboardAndConsoleSection: React.FC<{
             numResets={numResets}
             setNumResets={setNumResets}
             typedSentence={typedSentence}
+            isEasy={isEasy}
+            setIsEasy={setIsEasy}
          />
          <KeyboardDisplay
             bullseyeCounter={bullseyeCounter}
@@ -28,6 +31,7 @@ export const KeyboardAndConsoleSection: React.FC<{
             setKeyboardCounter={setKeyboardCounter}
             typedSentence={typedSentence}
             setTypedSentence={setTypedSentence}
+            isEasy={isEasy}
          />
       </div>
    );

--- a/src/routes/TypingPage/components/KeyboardDisplay/index.tsx
+++ b/src/routes/TypingPage/components/KeyboardDisplay/index.tsx
@@ -10,6 +10,7 @@ export const KeyboardDisplay: React.FC<{
    setKeyboardCounter: React.Dispatch<React.SetStateAction<number>>;
    typedSentence: string;
    setTypedSentence: React.Dispatch<React.SetStateAction<string>>;
+   isEasy: boolean;
 }> = ({
    bullseyeCounter,
    setBullseyeCounter,
@@ -17,6 +18,7 @@ export const KeyboardDisplay: React.FC<{
    setKeyboardCounter,
    typedSentence,
    setTypedSentence,
+   isEasy,
 }) => {
    const lettersTop = ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'];
    const lettersMiddle = ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l'];
@@ -39,6 +41,7 @@ export const KeyboardDisplay: React.FC<{
                      setBullseyeCounter={setBullseyeCounter}
                      typedSentence={typedSentence}
                      setTypedSentence={setTypedSentence}
+                     isEasy={isEasy}
                   />
                ))}
             </div>
@@ -52,6 +55,7 @@ export const KeyboardDisplay: React.FC<{
                      setBullseyeCounter={setBullseyeCounter}
                      typedSentence={typedSentence}
                      setTypedSentence={setTypedSentence}
+                     isEasy={isEasy}
                   />
                ))}
             </div>
@@ -65,6 +69,7 @@ export const KeyboardDisplay: React.FC<{
                      setBullseyeCounter={setBullseyeCounter}
                      typedSentence={typedSentence}
                      setTypedSentence={setTypedSentence}
+                     isEasy={isEasy}
                   />
                ))}
             </div>
@@ -78,6 +83,7 @@ export const KeyboardDisplay: React.FC<{
                      setBullseyeCounter={setBullseyeCounter}
                      typedSentence={typedSentence}
                      setTypedSentence={setTypedSentence}
+                     isEasy={isEasy}
                   />
                ))}
             </div>

--- a/src/routes/TypingPage/components/SampleSection/index.tsx
+++ b/src/routes/TypingPage/components/SampleSection/index.tsx
@@ -10,9 +10,9 @@ export const SampleSection: React.FC = () => {
             <div>Here is a sample sentence you can type:</div>
          </div>
          <div>
-            Not only is it the first time since 1993 that both conference No. 1
-            seeds have advanced to the Super Bowl, but this year also dispels
-            the notion that you need a dominant defense to win a championship.
+            Not only is it the first time that both top conference seeds have
+            advanced to the Super Bowl, but this year also dispels the notion
+            that you need a dominant defense to win a championship.
          </div>
       </div>
    );

--- a/src/routes/TypingPage/components/UserConsole/index.tsx
+++ b/src/routes/TypingPage/components/UserConsole/index.tsx
@@ -59,7 +59,7 @@ const Panel: React.FC<{
             bullseyeCounter={bullseyeCounter}
             keyboardCounter={keyboardCounter}
          />
-         <div onClick={() => setIsEasy(!isEasy)}>
+         <div className={styles.score} onClick={() => setIsEasy(!isEasy)}>
             {isEasy ? 'easy' : 'hard'}
          </div>
          <ResetButton numResets={numResets} setNumResets={setNumResets} />

--- a/src/routes/TypingPage/components/UserConsole/index.tsx
+++ b/src/routes/TypingPage/components/UserConsole/index.tsx
@@ -43,13 +43,25 @@ const Panel: React.FC<{
    keyboardCounter: number;
    numResets: number;
    setNumResets: React.Dispatch<React.SetStateAction<number>>;
-}> = ({ bullseyeCounter, keyboardCounter, numResets, setNumResets }) => {
+   isEasy: boolean;
+   setIsEasy: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({
+   bullseyeCounter,
+   keyboardCounter,
+   numResets,
+   setNumResets,
+   isEasy,
+   setIsEasy,
+}) => {
    return (
       <div className={styles.panel}>
          <Score
             bullseyeCounter={bullseyeCounter}
             keyboardCounter={keyboardCounter}
          />
+         <div onClick={() => setIsEasy(!isEasy)}>
+            {isEasy ? 'easy' : 'hard'}
+         </div>
          <ResetButton numResets={numResets} setNumResets={setNumResets} />
       </div>
    );
@@ -61,12 +73,16 @@ export const UserConsole: React.FC<{
    numResets: number;
    setNumResets: React.Dispatch<React.SetStateAction<number>>;
    typedSentence: string;
+   isEasy: boolean;
+   setIsEasy: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({
    bullseyeCounter,
    keyboardCounter,
    numResets,
    setNumResets,
    typedSentence,
+   isEasy,
+   setIsEasy,
 }) => {
    return (
       <div className={styles.userConsole}>
@@ -76,6 +92,8 @@ export const UserConsole: React.FC<{
             keyboardCounter={keyboardCounter}
             numResets={numResets}
             setNumResets={setNumResets}
+            isEasy={isEasy}
+            setIsEasy={setIsEasy}
          />
       </div>
    );

--- a/src/routes/TypingPage/components/UserConsole/style.module.css
+++ b/src/routes/TypingPage/components/UserConsole/style.module.css
@@ -43,6 +43,13 @@
    align-items: center;
 }
 
+.score {
+   background-color: #aaa;
+   border-radius: 5px;
+   padding: 0 6px;
+   font-weight: bold;
+}
+
 .reset {
    background: var(--nav-purple);
    padding: 0 7px;

--- a/src/routes/TypingPage/components/WholeKey/index.tsx
+++ b/src/routes/TypingPage/components/WholeKey/index.tsx
@@ -18,6 +18,7 @@ const MiniBox: React.FC<MiniBoxProps> = ({
    miniBoxId,
    gradientRecord,
    setGradientRecord,
+   isEasy,
 }) => {
    // const numMinisToShow = 3; //save
    // const [miniCounter, setMiniCounter] = useState(0); //save
@@ -28,7 +29,27 @@ const MiniBox: React.FC<MiniBoxProps> = ({
 
    return (
       <div
-         className={styles.miniBox}
+         className={classNames(
+            { [styles.miniBoxEasyCentral]: isEasy },
+            {
+               [styles.miniBoxEasyPeripheralWidth]:
+                  isEasy && [0, 3, 6, 2, 5, 8].includes(miniBoxId),
+            },
+            {
+               [styles.miniBoxEasyPeripheralHeight]:
+                  isEasy && [0, 1, 2, 6, 7, 8].includes(miniBoxId),
+            },
+
+            { [styles.miniBoxHardCentral]: !isEasy },
+            {
+               [styles.miniBoxHardPeripheralWidth]:
+                  !isEasy && [0, 3, 6, 2, 5, 8].includes(miniBoxId),
+            },
+            {
+               [styles.miniBoxHardPeripheralHeight]:
+                  !isEasy && [0, 1, 2, 6, 7, 8].includes(miniBoxId),
+            },
+         )}
          onClick={() => {
             setIsClicked(true);
             setKeyboardCounterSnapshot(keyboardCounter);
@@ -48,8 +69,33 @@ const MiniBox: React.FC<MiniBoxProps> = ({
                   src={miniBoxId === 4 ? TargetLogoHit : TargetLogoMiss}
                   alt="target logo"
                   className={classNames(
-                     styles.targetLogo,
-                     { [styles.targetSpacebar]: letter === ' ' },
+                     styles.target,
+
+                     {
+                        [styles.targetCentralWidth]:
+                           isEasy && [1, 4, 7].includes(miniBoxId),
+                     },
+
+                     {
+                        [styles.targetPeripheralWidth]:
+                           isEasy && [0, 3, 6, 2, 5, 8].includes(miniBoxId),
+                     },
+
+                     { [styles.targetSpacebar]: !isEasy && letter === ' ' },
+
+                     {
+                        [styles.targetSpacebarCentralWidth]:
+                           isEasy &&
+                           letter === ' ' &&
+                           [1, 4, 7].includes(miniBoxId),
+                     },
+
+                     {
+                        [styles.targetSpacebarPeripheralWidth]:
+                           isEasy &&
+                           letter === ' ' &&
+                           [0, 3, 6, 2, 5, 8].includes(miniBoxId),
+                     },
                      {
                         [styles.targetTrace]:
                            keyboardCounter - 1 !== keyBoardCounterSnapshot,
@@ -68,6 +114,7 @@ export const WholeKey: React.FC<WholeKeyProps> = ({
    keyboardCounter,
    typedSentence,
    setTypedSentence,
+   isEasy,
 }) => {
    const maxSentenceLength = 100;
    const miniBoxIds = [0, 1, 2, 3, 4, 5, 6, 7, 8];
@@ -119,6 +166,7 @@ export const WholeKey: React.FC<WholeKeyProps> = ({
                keyboardCounter={keyboardCounter}
                gradientRecord={gradientRecord}
                setGradientRecord={setGradientRecord}
+               isEasy={isEasy}
             />
          ))}
          <div

--- a/src/routes/TypingPage/components/WholeKey/style.module.css
+++ b/src/routes/TypingPage/components/WholeKey/style.module.css
@@ -1,25 +1,60 @@
-.miniBox {
+.miniBoxEasyCentral {
    position: relative;
-   width: 33%;
-   height: 33%;
    border-radius: 3px;
+   width: var(--easy-central);
+   height: var(--easy-central);
 }
 
-.targetLogo {
+.miniBoxEasyPeripheralWidth {
+   width: var(--easy-peripheral);
+}
+
+.miniBoxEasyPeripheralHeight {
+   height: var(--easy-peripheral);
+}
+
+.miniBoxHardCentral {
+   position: relative;
+   border-radius: 3px;
+   width: var(--hard-central);
+   height: var(--hard-central);
+}
+
+.miniBoxHardPeripheralWidth {
+   width: var(--hard-peripheral);
+}
+
+.miniBoxHardPeripheralHeight {
+   height: var(--hard-peripheral);
+}
+
+.target {
    position: absolute;
    pointer-events: none;
    top: calc(-0.5 * var(--key-width) + 50%);
-   left: calc(
-      -0.5 * var(--key-width) + 0.5 * var(--key-width) / var(--num-minis-in-row)
-   );
+   left: calc(-0.5 * var(--key-width) + 0.5 * var(--key-width) / 3);
    width: var(--key-width);
    z-index: 1;
 }
 
+.targetCentralWidth {
+   left: calc(-0.5 * var(--key-width) + 0.5 * var(--key-width) / 2);
+}
+
+.targetPeripheralWidth {
+   left: calc(-0.5 * var(--key-width) + 0.5 * var(--key-width) / 4);
+}
+
 .targetSpacebar {
-   left: calc(
-      -0.5 * var(--key-width) + 0.5 * var(--space-width) / var(--num-minis-in-row)
-   );
+   left: calc(-0.5 * var(--key-width) + 0.5 * var(--space-width) / 3);
+}
+
+.targetSpacebarCentralWidth {
+   left: calc(-0.5 * var(--key-width) + 0.5 * var(--space-width) / 2);
+}
+
+.targetSpacebarPeripheralWidth {
+   left: calc(-0.5 * var(--key-width) + 0.5 * var(--space-width) / 4);
 }
 
 .targetTrace {


### PR DESCRIPTION
Each key contains a 3x3 grid, or 9 mini-boxes.  When user clicks "hard", the central target box gets smaller and it is more difficult to get a good score. 
Easy: Central box is 50% of key width and height.
Hard: Central box is 33% of key width and height.